### PR TITLE
Fix bug in Media Search process

### DIFF
--- a/windows/MediaToolWindow.xaml.cs
+++ b/windows/MediaToolWindow.xaml.cs
@@ -473,8 +473,8 @@ namespace GamelistManager
                 string mediaType = item.MediaType;
                 string matchedFile = item.MatchedFile;
 
-                // Convert the full path to a relative path
-                string relativePath = FilePathHelper.ConvertPathToRelativePath(matchedFile, _parentFolderPath);
+                // Convert the full path to a gamelist-relative path
+                string relativePath = FilePathHelper.ConvertPathToGamelistRomPath(matchedFile, _parentFolderPath);
 
                 if (rowLookup.TryGetValue(item.RomPath, out DataRow? foundRow))
                 {


### PR DESCRIPTION
When using the Media Search UI to add existing media back to the gamelist, each media item is added without the `./` prefix e.g. `images/image.jpg` instead of `./images/image.jpg`. Fix this to match the behaviour of other parts of the system by calling the correct helper method.